### PR TITLE
feat: get test collection ids from properties

### DIFF
--- a/src/org/nyu/edu/dlts/dbCopyFrame.java
+++ b/src/org/nyu/edu/dlts/dbCopyFrame.java
@@ -175,6 +175,16 @@ public class dbCopyFrame extends JFrame {
 
                     ascopy = new ASpaceCopyUtil(archonClient, host, admin, adminPassword);
                     ascopy.setSimulateRESTCalls(simulateRESTCalls);
+                    String[] testCollectionsArray = {};
+                    if (UIUCPropertiesReader.getUIUCProperties() != null && UIUCPropertiesReader.getUIUCProperties().getProperty("testing.collections") != null) {
+                        String testCollections =  UIUCPropertiesReader.getUIUCProperties().getProperty("testing.collections");
+                        testCollectionsArray = testCollections.split(",");
+                    }
+                    ArrayList<String> readCollArchonIDsList = new ArrayList<String>();
+                    for (String id : testCollectionsArray) {
+                        readCollArchonIDsList.add(id);
+                    }
+                    ascopy.setCollArchonIDToCopyList(readCollArchonIDsList);
 
                     // set the reset password, and output console and progress bar
                     ascopy.setResetPassword(resetPasswordTextField.getText().trim());

--- a/src/org/nyu/edu/dlts/utils/ASpaceCopyUtil.java
+++ b/src/org/nyu/edu/dlts/utils/ASpaceCopyUtil.java
@@ -3653,18 +3653,16 @@ public class ASpaceCopyUtil implements  PrintConsole {
         aspaceCopyUtil.getSession();
         aspaceCopyUtil.setBBCodeOption("-bbcode_html");
 
-        //limit collections for testing
-        ArrayList<String> collectionsIDsList = new ArrayList<String>();
-        collectionsIDsList.add("54");
-        //collectionsIDsList.add("84");
-        //aspaceCopyUtil.setCollectionsToCopyList(collectionsIDsList);
-
         //limit collections for testing by archon collection ID
+        String[] testCollectionsArray = {};
+        if (UIUCPropertiesReader.getUIUCProperties() != null && UIUCPropertiesReader.getUIUCProperties().getProperty("testing.collections") != null) {
+            String testCollections =  UIUCPropertiesReader.getUIUCProperties().getProperty("testing.collections");
+            testCollectionsArray = testCollections.split(",");
+        }
         ArrayList<String> collArchonIDsList = new ArrayList<String>();
-        collArchonIDsList.add("7226");
-        collArchonIDsList.add("8302");
-        collArchonIDsList.add("7853");
-        collArchonIDsList.add("8734");
+        for (String id : testCollectionsArray) {
+            collArchonIDsList.add(id);
+        }
         aspaceCopyUtil.setCollArchonIDToCopyList(collArchonIDsList);
         
         archonClient.setDebugMode(false);


### PR DESCRIPTION
@graykr when I was going through branch 57 to see what may have been excluded from the merge and why, I kept getting tripped up on conflicts that arose from the setting the test collection ids here. I wonder if a cleaner strategy might be to use the property reader. That way you can just add to the uiuc.properties file the line:
`testing.collections=7226,8302,7853,8734`
with the ids for whatever collections you want to run for that test. I've sketched out what that might look like in this PR.

If this strategy appeals to you, I noticed that there was also a line `aspaceCopyUtil.mapper.setAppendTestIdentifier("0502test16")`
is this something that could also be populated from the properties file?
